### PR TITLE
Implement trade journal platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.sqlite3
+.venv/
+.env
+.env.*
+
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/
+
+# Logs
+*.log
+
+# VSCode
+.vscode/

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,62 @@
-this is a readme
-this is a readme
-this is a readme
-this is a readme
+# Trade Journal Platform
+
+A full-stack trade journal management system featuring a React + Vite frontend and a FastAPI backend backed by PostgreSQL. The application supports uploading IBKR trade data, calculating performance metrics, browsing trades, and visualising activity on a calendar.
+
+## Features
+
+- Unified filters (asset code, type, direction, date range presets) shared across dashboard and trade views.
+- Dashboard with win rate, total/average PnL, profit factor, and asset-level breakdown.
+- Trade log with expandable child trades, Pine Script export, and bulk deletion.
+- Calendar visualisation with per-day counts and PnL, with quick drill-down to trades.
+- Data import pipeline with validation for IBKR CSV files and automatic parent-trade aggregation.
+- Timezone-aware filtering and display, user-configurable from the UI.
+
+## Getting Started
+
+### Local Development (without Docker)
+
+1. **Backend**
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   pip install -r requirements.txt
+   export DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/tradej"
+   uvicorn app.main:app --reload
+   ```
+
+2. **Frontend**
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+### Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The backend will be accessible at `http://localhost:8000`, and the Vite dev server at `http://localhost:5173`.
+
+## Testing
+
+Run backend tests with:
+
+```bash
+cd backend
+pytest
+```
+
+Frontend build check:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+## Mock Data
+
+A sample IBKR CSV file is available under `mock/TradeNote.csv` for testing the import pipeline.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async for session in get_session():
+        yield session

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from app.api.routes import calendar, imports, settings, stats, trades
+
+api_router = APIRouter()
+api_router.include_router(imports.router)
+api_router.include_router(trades.router)
+api_router.include_router(stats.router)
+api_router.include_router(calendar.router)
+api_router.include_router(settings.router)

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import get_db
+from app.models import Asset, AssetType, ParentTrade
+from app.models.trade import TradeDirection
+from app.schemas.calendar import CalendarDay
+
+router = APIRouter(prefix="/api/calendar", tags=["calendar"])
+
+
+def _month_bounds(year: int, month: int, timezone: str) -> tuple[datetime, datetime]:
+    tz = ZoneInfo(timezone)
+    try:
+        start_local = datetime(year, month, 1, tzinfo=tz)
+    except ValueError as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail="Invalid year or month") from exc
+    if month == 12:
+        end_local = datetime(year + 1, 1, 1, tzinfo=tz)
+    else:
+        end_local = datetime(year, month + 1, 1, tzinfo=tz)
+    return start_local.astimezone(ZoneInfo("UTC")), end_local.astimezone(ZoneInfo("UTC"))
+
+
+@router.get("", response_model=list[CalendarDay])
+async def calendar_view(
+    year: int = Query(..., ge=1900, le=2100),
+    month: int = Query(..., ge=1, le=12),
+    asset_code: str | None = None,
+    asset_type: AssetType | None = None,
+    direction: TradeDirection | None = None,
+    timezone: str = Query(default="UTC"),
+    db: AsyncSession = Depends(get_db),
+) -> list[CalendarDay]:
+    start_utc, end_utc = _month_bounds(year, month, timezone)
+
+    stmt = (
+        select(ParentTrade)
+        .join(Asset)
+        .options(selectinload(ParentTrade.asset))
+        .where(
+            (
+                (ParentTrade.close_time >= start_utc)
+                & (ParentTrade.close_time < end_utc)
+                & ParentTrade.close_time.is_not(None)
+            )
+            | (
+                ParentTrade.close_time.is_(None)
+                & (ParentTrade.open_time >= start_utc)
+                & (ParentTrade.open_time < end_utc)
+            )
+        )
+    )
+    conditions = []
+    if asset_code:
+        conditions.append(Asset.code == asset_code)
+    if asset_type:
+        conditions.append(Asset.asset_type == asset_type)
+    if direction:
+        conditions.append(ParentTrade.direction == direction)
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    result = await db.execute(stmt)
+    trades = result.scalars().all()
+
+    tz = ZoneInfo(timezone)
+    buckets: dict[date, dict[str, float | int]] = defaultdict(lambda: {"count": 0, "pnl": 0.0})
+
+    for trade in trades:
+        reference = trade.close_time or trade.open_time
+        local_dt = reference.astimezone(tz)
+        day = local_dt.date()
+        bucket = buckets[day]
+        bucket["count"] = int(bucket["count"]) + 1
+        bucket["pnl"] = float(bucket["pnl"]) + float(trade.profit_loss)
+
+    return [
+        CalendarDay(date=day, trade_count=int(data["count"]), total_profit_loss=float(data["pnl"]))
+        for day, data in sorted(buckets.items(), key=lambda item: item[0])
+    ]

--- a/backend/app/api/routes/imports.py
+++ b/backend/app/api/routes/imports.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.models import ImportBatch
+from app.schemas.imports import ImportBatchRead
+from app.services.ibkr_importer import ImportValidationError, import_ibkr_csv
+
+router = APIRouter(prefix="/api/imports", tags=["imports"])
+
+
+@router.post("", response_model=ImportBatchRead, status_code=status.HTTP_201_CREATED)
+async def create_import(
+    broker: str = Form(...),
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+) -> ImportBatch:
+    if broker.lower() != "ibkr":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported broker")
+    contents = await file.read()
+    if not contents:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empty file uploaded")
+    try:
+        batch = await import_ibkr_csv(db, contents, file.filename)
+        await db.commit()
+    except ImportValidationError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to import trades") from exc
+    await db.refresh(batch)
+    return batch
+
+
+@router.get("", response_model=list[ImportBatchRead])
+async def list_imports(db: AsyncSession = Depends(get_db)) -> list[ImportBatch]:
+    result = await db.execute(select(ImportBatch).order_by(ImportBatch.created_at.desc()))
+    return result.scalars().all()

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_db
+from app.core.config import get_settings
+from app.models import UserSetting
+from app.schemas.settings import SettingsRead, SettingsUpdate
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+@router.get("", response_model=SettingsRead)
+async def get_user_settings(db: AsyncSession = Depends(get_db)) -> SettingsRead:
+    result = await db.execute(select(UserSetting).limit(1))
+    setting = result.scalar_one_or_none()
+    if setting is None:
+        default_timezone = get_settings().default_timezone
+        setting = UserSetting(timezone=default_timezone)
+        db.add(setting)
+        await db.commit()
+        await db.refresh(setting)
+    return SettingsRead(timezone=setting.timezone)
+
+
+@router.patch("", response_model=SettingsRead)
+async def update_user_settings(
+    payload: SettingsUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> SettingsRead:
+    result = await db.execute(select(UserSetting).limit(1))
+    setting = result.scalar_one_or_none()
+    if setting is None:
+        setting = UserSetting(timezone=payload.timezone)
+        db.add(setting)
+    else:
+        setting.timezone = payload.timezone
+    await db.commit()
+    await db.refresh(setting)
+    return SettingsRead(timezone=setting.timezone)

--- a/backend/app/api/routes/stats.py
+++ b/backend/app/api/routes/stats.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import get_db
+from app.models import Asset, AssetType, ParentTrade
+from app.models.trade import TradeDirection
+from app.schemas.stats import AssetBreakdown, OverviewStats
+
+router = APIRouter(prefix="/api/stats", tags=["stats"])
+
+
+def _parse_datetime(dt: datetime | None, timezone: str) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        tz = ZoneInfo(timezone)
+        dt = dt.replace(tzinfo=tz)
+    return dt.astimezone(ZoneInfo("UTC"))
+
+
+def _load_trades(
+    asset_code: str | None,
+    asset_type: AssetType | None,
+    direction: TradeDirection | None,
+    start_utc: datetime | None,
+    end_utc: datetime | None,
+):
+    stmt = (
+        select(ParentTrade)
+        .join(Asset)
+        .options(selectinload(ParentTrade.asset))
+        .order_by(ParentTrade.open_time.desc())
+    )
+    conditions = []
+    if asset_code:
+        conditions.append(Asset.code == asset_code)
+    if asset_type:
+        conditions.append(Asset.asset_type == asset_type)
+    if direction:
+        conditions.append(ParentTrade.direction == direction)
+    if start_utc:
+        conditions.append(ParentTrade.open_time >= start_utc)
+    if end_utc:
+        conditions.append(ParentTrade.open_time <= end_utc)
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+    return stmt
+
+
+@router.get("/overview", response_model=OverviewStats)
+async def get_overview(
+    asset_code: str | None = None,
+    asset_type: AssetType | None = None,
+    direction: TradeDirection | None = None,
+    start: datetime | None = Query(default=None),
+    end: datetime | None = Query(default=None),
+    timezone: str = Query(default="UTC"),
+    db: AsyncSession = Depends(get_db),
+) -> OverviewStats:
+    start_utc = _parse_datetime(start, timezone)
+    end_utc = _parse_datetime(end, timezone)
+    stmt = _load_trades(asset_code, asset_type, direction, start_utc, end_utc)
+    result = await db.execute(stmt)
+    trades = result.scalars().all()
+
+    total = len(trades)
+    if total == 0:
+        return OverviewStats(
+            total_trades=0,
+            win_rate=0.0,
+            total_profit_loss=0.0,
+            average_profit_loss=0.0,
+            profit_loss_ratio=None,
+            profit_factor=None,
+        )
+
+    total_pnl = sum(float(trade.profit_loss) for trade in trades)
+    wins = [float(trade.profit_loss) for trade in trades if float(trade.profit_loss) > 0]
+    losses = [float(trade.profit_loss) for trade in trades if float(trade.profit_loss) < 0]
+
+    win_rate = len(wins) / total if total else 0.0
+    average = total_pnl / total
+    avg_win = (sum(wins) / len(wins)) if wins else None
+    avg_loss = (sum(losses) / len(losses)) if losses else None
+    profit_loss_ratio = (
+        avg_win / abs(avg_loss)
+        if avg_win is not None and avg_loss is not None and avg_loss != 0
+        else None
+    )
+    profit_factor = (
+        sum(wins) / abs(sum(losses))
+        if wins and losses and sum(losses) != 0
+        else None
+    )
+
+    return OverviewStats(
+        total_trades=total,
+        win_rate=win_rate,
+        total_profit_loss=total_pnl,
+        average_profit_loss=average,
+        profit_loss_ratio=profit_loss_ratio,
+        profit_factor=profit_factor,
+    )
+
+
+@router.get("/by-asset", response_model=list[AssetBreakdown])
+async def stats_by_asset(
+    asset_code: str | None = None,
+    asset_type: AssetType | None = None,
+    direction: TradeDirection | None = None,
+    start: datetime | None = Query(default=None),
+    end: datetime | None = Query(default=None),
+    timezone: str = Query(default="UTC"),
+    db: AsyncSession = Depends(get_db),
+) -> list[AssetBreakdown]:
+    start_utc = _parse_datetime(start, timezone)
+    end_utc = _parse_datetime(end, timezone)
+    stmt = _load_trades(asset_code, asset_type, direction, start_utc, end_utc)
+    result = await db.execute(stmt)
+    trades = result.scalars().all()
+
+    summary: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {
+            "asset_type": "",
+            "trade_count": 0,
+            "wins": 0,
+            "total_pnl": 0.0,
+        }
+    )
+
+    for trade in trades:
+        key = trade.asset.code
+        entry = summary[key]
+        entry["asset_type"] = trade.asset.asset_type.value
+        entry["trade_count"] = int(entry["trade_count"]) + 1
+        pnl = float(trade.profit_loss)
+        if pnl > 0:
+            entry["wins"] = int(entry["wins"]) + 1
+        entry["total_pnl"] = float(entry["total_pnl"]) + pnl
+
+    breakdown = [
+        AssetBreakdown(
+            asset_code=code,
+            asset_type=str(data["asset_type"]),
+            trade_count=int(data["trade_count"]),
+            win_rate=(int(data["wins"]) / int(data["trade_count"])) if data["trade_count"] else 0.0,
+            total_profit_loss=float(data["total_pnl"]),
+        )
+        for code, data in summary.items()
+    ]
+
+    breakdown.sort(key=lambda item: item.trade_count, reverse=True)
+    return breakdown

--- a/backend/app/api/routes/trades.py
+++ b/backend/app/api/routes/trades.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi.responses import PlainTextResponse
+from sqlalchemy import and_, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import get_db
+from app.models import Asset, AssetType, ParentTrade, TradeFill
+from app.models.trade import FillSide, TradeDirection
+from app.schemas.trade import ParentTradeWithFills, TradeFillBase
+
+router = APIRouter(prefix="/api/trades", tags=["trades"])
+
+
+def _parse_datetime(dt: datetime | None, timezone: str) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        tz = ZoneInfo(timezone)
+        dt = dt.replace(tzinfo=tz)
+    return dt.astimezone(ZoneInfo("UTC"))
+
+
+def _serialize_trade(trade: ParentTrade) -> ParentTradeWithFills:
+    fills = [
+        TradeFillBase(
+            id=fill.id,
+            side=fill.side,
+            quantity=float(fill.quantity),
+            price=float(fill.price),
+            commission=float(fill.commission),
+            currency=fill.currency,
+            trade_time=fill.trade_time,
+            source=fill.source,
+            order_id=fill.order_id,
+        )
+        for fill in sorted(trade.fills, key=lambda f: f.trade_time)
+    ]
+    return ParentTradeWithFills(
+        id=trade.id,
+        asset_id=trade.asset_id,
+        asset_code=trade.asset.code,
+        asset_type=trade.asset.asset_type,
+        direction=trade.direction,
+        quantity=float(trade.quantity),
+        open_time=trade.open_time,
+        close_time=trade.close_time,
+        open_price=float(trade.open_price) if trade.open_price is not None else None,
+        close_price=float(trade.close_price) if trade.close_price is not None else None,
+        total_commission=float(trade.total_commission),
+        profit_loss=float(trade.profit_loss),
+        currency=trade.currency,
+        fills=fills,
+    )
+
+
+@router.get("", response_model=list[ParentTradeWithFills])
+async def list_trades(
+    asset_code: str | None = None,
+    asset_type: AssetType | None = None,
+    direction: TradeDirection | None = None,
+    start: datetime | None = Query(default=None),
+    end: datetime | None = Query(default=None),
+    timezone: str = Query(default="UTC"),
+    db: AsyncSession = Depends(get_db),
+) -> list[ParentTradeWithFills]:
+    start_utc = _parse_datetime(start, timezone)
+    end_utc = _parse_datetime(end, timezone)
+
+    stmt = (
+        select(ParentTrade)
+        .join(Asset)
+        .options(selectinload(ParentTrade.asset), selectinload(ParentTrade.fills))
+        .order_by(ParentTrade.open_time.desc())
+    )
+
+    conditions = []
+    if asset_code:
+        conditions.append(Asset.code == asset_code)
+    if asset_type:
+        conditions.append(Asset.asset_type == asset_type)
+    if direction:
+        conditions.append(ParentTrade.direction == direction)
+    if start_utc:
+        conditions.append(ParentTrade.open_time >= start_utc)
+    if end_utc:
+        conditions.append(ParentTrade.open_time <= end_utc)
+
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    result = await db.execute(stmt)
+    trades = result.scalars().unique().all()
+    return [_serialize_trade(trade) for trade in trades]
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_all_trades(db: AsyncSession = Depends(get_db)) -> Response:
+    await db.execute(delete(TradeFill))
+    await db.execute(delete(ParentTrade))
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/fills/export", response_class=PlainTextResponse)
+async def export_fills(
+    asset_code: str | None = None,
+    start: datetime | None = Query(default=None),
+    end: datetime | None = Query(default=None),
+    timezone: str = Query(default="UTC"),
+    db: AsyncSession = Depends(get_db),
+) -> str:
+    start_utc = _parse_datetime(start, timezone)
+    end_utc = _parse_datetime(end, timezone)
+
+    stmt = select(TradeFill).join(Asset).options(selectinload(TradeFill.asset)).order_by(TradeFill.trade_time)
+    if asset_code:
+        stmt = stmt.where(Asset.code == asset_code)
+    if start_utc:
+        stmt = stmt.where(TradeFill.trade_time >= start_utc)
+    if end_utc:
+        stmt = stmt.where(TradeFill.trade_time <= end_utc)
+
+    result = await db.execute(stmt)
+    fills = result.scalars().all()
+    if not fills:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No fills to export")
+
+    lines = ["//@version=5", "indicator(\"Trade Journal Fills\", overlay=true)"]
+    lines.append("var int[] tradeTimes = array.new_int()")
+    lines.append("var string[] tradeTexts = array.new_string()")
+    lines.append("if barstate.isfirst")
+    for fill in fills:
+        timestamp = int(fill.trade_time.timestamp() * 1000)
+        side_text = "BUY" if fill.side == FillSide.BUY else "SELL"
+        text = f"{fill.asset.code} {side_text} {float(fill.quantity)}@{float(fill.price)}"
+        safe_text = text.replace("\"", "\\\"")
+        lines.append(f"    array.push(tradeTimes, {timestamp})")
+        lines.append(f"    array.push(tradeTexts, \"{safe_text}\")")
+    lines.append("for i = 0 to array.size(tradeTimes) - 1")
+    lines.append("    if time == array.get(tradeTimes, i)")
+    lines.append(
+        "        label.new(bar_index, close, array.get(tradeTexts, i), style=label.style_label_down, color=color.new(color.blue, 0))"
+    )
+
+    return "\n".join(lines)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    app_name: str = "Trade Journal"
+    debug: bool = False
+    database_url: str = "postgresql+asyncpg://postgres:postgres@db:5432/tradej"
+    default_timezone: str = "America/New_York"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,14 @@
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import get_settings
+
+settings = get_settings()
+engine = create_async_engine(settings.database_url, echo=settings.debug, future=True)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api.routes import api_router
+from app.db.base import Base
+from app.db.session import engine
+
+app = FastAPI(title="Trade Journal API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+    allow_credentials=True,
+)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+app.include_router(api_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,16 @@
+from app.models.asset import Asset, AssetType
+from app.models.import_batch import ImportBatch, ImportStatus
+from app.models.trade import FillSide, ParentTrade, TradeDirection, TradeFill
+from app.models.user_setting import UserSetting
+
+__all__ = [
+    "Asset",
+    "AssetType",
+    "ImportBatch",
+    "ImportStatus",
+    "ParentTrade",
+    "TradeDirection",
+    "TradeFill",
+    "FillSide",
+    "UserSetting",
+]

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import DateTime, Enum, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class AssetType(str, PyEnum):
+    STOCK = "stock"
+    OPTION = "option"
+    FUTURE = "future"
+
+
+class Asset(Base):
+    __tablename__ = "assets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    code: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    name: Mapped[str | None] = mapped_column(String(200))
+    asset_type: Mapped[AssetType] = mapped_column(Enum(AssetType, name="asset_type"))
+    exchange: Mapped[str | None] = mapped_column(String(50))
+    timezone: Mapped[str] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    trades: Mapped[list["ParentTrade"]] = relationship(back_populates="asset")
+    fills: Mapped[list["TradeFill"]] = relationship(back_populates="asset")

--- a/backend/app/models/import_batch.py
+++ b/backend/app/models/import_batch.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import DateTime, Enum, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ImportStatus(str, PyEnum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ImportBatch(Base):
+    __tablename__ = "import_batches"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    broker: Mapped[str] = mapped_column(String(50))
+    filename: Mapped[str] = mapped_column(String(255))
+    status: Mapped[ImportStatus] = mapped_column(Enum(ImportStatus, name="import_status"), default=ImportStatus.PENDING)
+    error_message: Mapped[str | None] = mapped_column(String)
+    total_records: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    timezone: Mapped[str | None] = mapped_column(String(50))
+
+    fills: Mapped[list["TradeFill"]] = relationship(back_populates="import_batch", cascade="all, delete-orphan")

--- a/backend/app/models/trade.py
+++ b/backend/app/models/trade.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+from app.models.asset import Asset
+from app.models.import_batch import ImportBatch
+
+
+class TradeDirection(str, PyEnum):
+    LONG = "long"
+    SHORT = "short"
+
+
+class FillSide(str, PyEnum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class ParentTrade(Base):
+    __tablename__ = "parent_trades"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    asset_id: Mapped[int] = mapped_column(ForeignKey("assets.id"))
+    direction: Mapped[TradeDirection] = mapped_column(Enum(TradeDirection, name="trade_direction"))
+    quantity: Mapped[float] = mapped_column(Numeric(18, 4))
+    open_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    close_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    open_price: Mapped[float | None] = mapped_column(Numeric(18, 6))
+    close_price: Mapped[float | None] = mapped_column(Numeric(18, 6))
+    total_commission: Mapped[float] = mapped_column(Numeric(18, 6), default=0)
+    profit_loss: Mapped[float] = mapped_column(Numeric(18, 6), default=0)
+    currency: Mapped[str] = mapped_column(String(10))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    asset: Mapped[Asset] = relationship(back_populates="trades")
+    fills: Mapped[list["TradeFill"]] = relationship(back_populates="parent_trade", cascade="all, delete-orphan")
+
+
+class TradeFill(Base):
+    __tablename__ = "trade_fills"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    parent_trade_id: Mapped[int | None] = mapped_column(ForeignKey("parent_trades.id"), nullable=True)
+    asset_id: Mapped[int] = mapped_column(ForeignKey("assets.id"))
+    side: Mapped[FillSide] = mapped_column(Enum(FillSide, name="fill_side"))
+    quantity: Mapped[float] = mapped_column(Numeric(18, 4))
+    price: Mapped[float] = mapped_column(Numeric(18, 6))
+    commission: Mapped[float] = mapped_column(Numeric(18, 6), default=0)
+    currency: Mapped[str] = mapped_column(String(10))
+    trade_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    source: Mapped[str | None] = mapped_column(String(50))
+    order_id: Mapped[str | None] = mapped_column(String(100))
+    import_batch_id: Mapped[int] = mapped_column(ForeignKey("import_batches.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+
+    parent_trade: Mapped[ParentTrade | None] = relationship(back_populates="fills")
+    asset: Mapped[Asset] = relationship(back_populates="fills")
+    import_batch: Mapped[ImportBatch] = relationship(back_populates="fills")

--- a/backend/app/models/user_setting.py
+++ b/backend/app/models/user_setting.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class UserSetting(Base):
+    __tablename__ = "user_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    timezone: Mapped[str] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class CalendarDay(BaseModel):
+    date: date
+    trade_count: int
+    total_profit_loss: float

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.import_batch import ImportStatus
+
+
+class ImportBatchRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    broker: str
+    filename: str
+    status: ImportStatus
+    error_message: str | None
+    total_records: int
+    created_at: datetime
+    completed_at: datetime | None
+    timezone: str | None
+

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SettingsRead(BaseModel):
+    timezone: str = Field(default="America/New_York")
+
+
+class SettingsUpdate(BaseModel):
+    timezone: str

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class OverviewStats(BaseModel):
+    total_trades: int
+    win_rate: float
+    total_profit_loss: float
+    average_profit_loss: float
+    profit_loss_ratio: float | None
+    profit_factor: float | None
+
+
+class AssetBreakdown(BaseModel):
+    asset_code: str
+    asset_type: str
+    trade_count: int
+    win_rate: float
+    total_profit_loss: float

--- a/backend/app/schemas/trade.py
+++ b/backend/app/schemas/trade.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.asset import AssetType
+from app.models.trade import FillSide, TradeDirection
+
+
+class TradeFillBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    side: FillSide
+    quantity: float
+    price: float
+    commission: float
+    currency: str
+    trade_time: datetime
+    source: str | None = None
+    order_id: str | None = None
+
+class ParentTradeBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    asset_id: int
+    asset_code: str
+    asset_type: AssetType
+    direction: TradeDirection
+    quantity: float
+    open_time: datetime
+    close_time: datetime | None
+    open_price: float | None
+    close_price: float | None
+    total_commission: float
+    profit_loss: float
+    currency: str
+
+class ParentTradeWithFills(ParentTradeBase):
+    fills: Sequence[TradeFillBase]

--- a/backend/app/services/aggregation.py
+++ b/backend/app/services/aggregation.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable
+
+from app.models.asset import AssetType
+from app.models.trade import FillSide, TradeDirection
+
+
+@dataclass
+class NormalizedFill:
+    asset_code: str
+    asset_type: AssetType
+    exchange: str | None
+    timezone: str
+    trade_time: datetime
+    side: FillSide
+    quantity: float
+    price: float
+    commission: float
+    currency: str
+    order_id: str | None = None
+    source: str | None = None
+
+
+@dataclass
+class AggregatedTrade:
+    asset_code: str
+    asset_type: AssetType
+    direction: TradeDirection
+    quantity: float
+    open_time: datetime
+    close_time: datetime | None
+    open_price: float | None
+    close_price: float | None
+    total_commission: float
+    profit_loss: float
+    currency: str
+    fill_indexes: list[int] = field(default_factory=list)
+
+
+def aggregate_parent_trades(fills: Iterable[NormalizedFill]) -> tuple[list[AggregatedTrade], dict[int, int]]:
+    ordered_fills = sorted(enumerate(fills), key=lambda item: item[1].trade_time)
+    fill_lookup = {index: fill for index, fill in ordered_fills}
+    parent_trades: list[AggregatedTrade] = []
+    fill_to_parent: dict[int, int] = {}
+    state_by_asset: dict[str, dict] = {}
+
+    for index, fill in ordered_fills:
+        state = state_by_asset.get(fill.asset_code)
+        signed_qty = fill.quantity if fill.side == FillSide.BUY else -fill.quantity
+
+        if state is None or state.get("position", 0.0) == 0:
+            direction = TradeDirection.LONG if signed_qty > 0 else TradeDirection.SHORT
+            state = {
+                "direction": direction,
+                "asset_code": fill.asset_code,
+                "asset_type": fill.asset_type,
+                "position": 0.0,
+                "open_time": fill.trade_time,
+                "fills": [],
+                "open_sum_qty": 0.0,
+                "open_sum_amount": 0.0,
+                "close_sum_qty": 0.0,
+                "close_sum_amount": 0.0,
+                "total_commission": 0.0,
+                "cash_flow": 0.0,
+                "max_abs_position": 0.0,
+                "currency": fill.currency,
+            }
+            state_by_asset[fill.asset_code] = state
+
+        state["fills"].append(index)
+        position_before = state["position"]
+        position_after = position_before + signed_qty
+        abs_before = abs(position_before)
+        abs_after = abs(position_after)
+
+        open_qty = 0.0
+        close_qty = 0.0
+        if position_before == 0:
+            open_qty = abs(signed_qty)
+        elif position_before * position_after >= 0:
+            if abs_after > abs_before:
+                open_qty = abs_after - abs_before
+            elif abs_after < abs_before:
+                close_qty = abs_before - abs_after
+        else:
+            close_qty = abs_before
+            open_qty = abs_after
+
+        if open_qty > 0:
+            state["open_sum_qty"] += open_qty
+            state["open_sum_amount"] += open_qty * float(fill.price)
+
+        if close_qty > 0:
+            state["close_sum_qty"] += close_qty
+            state["close_sum_amount"] += close_qty * float(fill.price)
+
+        if signed_qty > 0:
+            state["cash_flow"] -= float(fill.price) * float(fill.quantity)
+        else:
+            state["cash_flow"] += float(fill.price) * float(fill.quantity)
+
+        state["total_commission"] += float(fill.commission)
+        state["position"] = position_after
+        state["max_abs_position"] = max(state["max_abs_position"], abs_after)
+
+        if position_after == 0:
+            open_price = (
+                float(state["open_sum_amount"]) / float(state["open_sum_qty"])
+                if state["open_sum_qty"] > 0
+                else None
+            )
+            close_price = (
+                float(state["close_sum_amount"]) / float(state["close_sum_qty"])
+                if state["close_sum_qty"] > 0
+                else None
+            )
+            parent_index = len(parent_trades)
+            parent_trades.append(
+                AggregatedTrade(
+                    asset_code=state["asset_code"],
+                    asset_type=state["asset_type"],
+                    direction=state["direction"],
+                    quantity=float(state["max_abs_position"]),
+                    open_time=state["open_time"],
+                    close_time=fill.trade_time,
+                    open_price=open_price,
+                    close_price=close_price,
+                    total_commission=float(state["total_commission"]),
+                    profit_loss=float(state["cash_flow"]) - float(state["total_commission"]),
+                    currency=state["currency"],
+                    fill_indexes=list(state["fills"]),
+                )
+            )
+            for fill_index in state["fills"]:
+                fill_to_parent[fill_index] = parent_index
+            state_by_asset.pop(fill.asset_code, None)
+        else:
+            state_by_asset[fill.asset_code] = state
+
+    for state in state_by_asset.values():
+        open_price = (
+            float(state["open_sum_amount"]) / float(state["open_sum_qty"])
+            if state["open_sum_qty"] > 0
+            else None
+        )
+        close_price = (
+            float(state["close_sum_amount"]) / float(state["close_sum_qty"])
+            if state["close_sum_qty"] > 0
+            else None
+        )
+        parent_index = len(parent_trades)
+        parent_trades.append(
+            AggregatedTrade(
+                asset_code=state["asset_code"],
+                asset_type=state["asset_type"],
+                direction=state["direction"],
+                quantity=float(state["max_abs_position"]) or abs(float(state["position"])),
+                open_time=state["open_time"],
+                close_time=None,
+                open_price=open_price,
+                close_price=close_price,
+                total_commission=float(state["total_commission"]),
+                profit_loss=float(state["cash_flow"]) - float(state["total_commission"]),
+                currency=state["currency"],
+                fill_indexes=list(state["fills"]),
+            )
+        )
+        for fill_index in state["fills"]:
+            fill_to_parent[fill_index] = parent_index
+
+    return parent_trades, fill_to_parent

--- a/backend/app/services/ibkr_importer.py
+++ b/backend/app/services/ibkr_importer.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    Asset,
+    AssetType,
+    ImportBatch,
+    ImportStatus,
+    ParentTrade,
+    TradeFill,
+)
+from app.models.trade import FillSide
+from app.services.aggregation import NormalizedFill, aggregate_parent_trades
+
+EXCHANGE_TIMEZONES = {
+    "ARCA": "America/New_York",
+    "NYSE": "America/New_York",
+    "NASDAQ": "America/New_York",
+    "CBOE": "America/Chicago",
+    "CME": "America/Chicago",
+    "SMART": "America/New_York",
+}
+
+ASSET_TYPE_MAP = {
+    "STK": AssetType.STOCK,
+    "OPT": AssetType.OPTION,
+    "FUT": AssetType.FUTURE,
+}
+
+REQUIRED_COLUMNS = {
+    "Date/Time",
+    "Symbol",
+    "Buy/Sell",
+    "Quantity",
+    "Price",
+    "Commission",
+    "CurrencyPrimary",
+}
+
+
+class ImportValidationError(Exception):
+    def __init__(self, message: str, row_number: int | None = None) -> None:
+        if row_number is not None:
+            super().__init__(f"Row {row_number}: {message}")
+        else:
+            super().__init__(message)
+
+
+def _parse_ibkr_datetime(value: str, timezone: str) -> datetime:
+    try:
+        date_part, time_part = value.split(";")
+        dt = datetime.strptime(f"{date_part}{time_part}", "%Y%m%d%H%M%S")
+    except Exception as exc:  # noqa: BLE001
+        raise ImportValidationError(f"Invalid Date/Time value: {value}") from exc
+    tz = ZoneInfo(timezone)
+    return dt.replace(tzinfo=tz).astimezone(ZoneInfo("UTC"))
+
+
+def _normalize_row(row: dict[str, str], row_number: int) -> NormalizedFill:
+    missing = [col for col in REQUIRED_COLUMNS if not row.get(col)]
+    if missing:
+        raise ImportValidationError(f"Missing required columns: {', '.join(missing)}", row_number)
+
+    symbol = row["Symbol"].strip()
+    asset_class = row.get("AssetClass", "STK").strip()
+    asset_type = ASSET_TYPE_MAP.get(asset_class, AssetType.STOCK)
+    side_str = row["Buy/Sell"].strip().upper()
+    if side_str not in ("BUY", "SELL"):
+        raise ImportValidationError("Buy/Sell must be BUY or SELL", row_number)
+    side = FillSide(side_str)
+
+    try:
+        quantity = abs(float(row["Quantity"]))
+    except ValueError as exc:
+        raise ImportValidationError("Quantity must be a number", row_number) from exc
+    if quantity <= 0:
+        raise ImportValidationError("Quantity must be greater than 0", row_number)
+
+    try:
+        price = float(row["Price"])
+    except ValueError as exc:
+        raise ImportValidationError("Price must be a number", row_number) from exc
+    if price <= 0:
+        raise ImportValidationError("Price must be greater than 0", row_number)
+
+    try:
+        commission_raw = float(row["Commission"])
+    except ValueError as exc:
+        raise ImportValidationError("Commission must be a number", row_number) from exc
+    commission = abs(commission_raw)
+    if commission < 0:
+        raise ImportValidationError("Commission cannot be negative", row_number)
+
+    currency = row["CurrencyPrimary"].strip()
+    if not currency:
+        raise ImportValidationError("Currency is required", row_number)
+
+    exchange_field = row.get("ListingExchange", "")
+    exchange = exchange_field.split(",")[0].split(";")[0].strip().upper() or None
+    timezone = EXCHANGE_TIMEZONES.get(exchange, "America/New_York")
+    trade_time = _parse_ibkr_datetime(row["Date/Time"], timezone)
+
+    return NormalizedFill(
+        asset_code=symbol,
+        asset_type=asset_type,
+        exchange=exchange,
+        timezone=timezone,
+        trade_time=trade_time,
+        side=side,
+        quantity=quantity,
+        price=price,
+        commission=commission,
+        currency=currency,
+        order_id=row.get("OrderID", "").strip() or None,
+        source=row.get("TradeID", "").strip() or None,
+    )
+
+
+async def import_ibkr_csv(
+    session: AsyncSession,
+    file_bytes: bytes,
+    filename: str,
+) -> ImportBatch:
+    csv_buffer = io.StringIO(file_bytes.decode("utf-8-sig"))
+    reader = csv.DictReader(csv_buffer)
+    if not reader.fieldnames:
+        raise ImportValidationError("CSV header is missing")
+    missing_columns = [col for col in REQUIRED_COLUMNS if col not in reader.fieldnames]
+    if missing_columns:
+        raise ImportValidationError(f"Missing required columns: {', '.join(missing_columns)}")
+
+    fills: list[NormalizedFill] = []
+    for idx, row in enumerate(reader, start=2):  # account for header line
+        fills.append(_normalize_row(row, idx))
+
+    if not fills:
+        raise ImportValidationError("No trade rows found in file")
+
+    aggregated_trades, _ = aggregate_parent_trades(fills)
+
+    batch = ImportBatch(
+        broker="ibkr",
+        filename=filename,
+        status=ImportStatus.PENDING,
+        total_records=len(fills),
+        timezone="UTC",
+    )
+    session.add(batch)
+    await session.flush()
+
+    asset_cache: dict[str, Asset] = {}
+
+    async def get_asset(symbol: str, asset_type: AssetType, timezone: str, exchange: str | None) -> Asset:
+        if symbol in asset_cache:
+            return asset_cache[symbol]
+        result = await session.execute(select(Asset).where(Asset.code == symbol))
+        asset = result.scalar_one_or_none()
+        if asset is None:
+            asset = Asset(code=symbol, asset_type=asset_type, timezone=timezone, exchange=exchange, name=symbol)
+            session.add(asset)
+            await session.flush()
+        else:
+            updated = False
+            if not asset.exchange and exchange:
+                asset.exchange = exchange
+                updated = True
+            if asset.timezone != timezone:
+                asset.timezone = timezone
+                updated = True
+            if updated:
+                await session.flush()
+        asset_cache[symbol] = asset
+        return asset
+
+    parent_models: list[tuple[list[int], ParentTrade]] = []
+    for trade in aggregated_trades:
+        first_fill = fills[trade.fill_indexes[0]]
+        asset = await get_asset(first_fill.asset_code, first_fill.asset_type, first_fill.timezone, first_fill.exchange)
+        parent = ParentTrade(
+            asset_id=asset.id,
+            direction=trade.direction,
+            quantity=trade.quantity,
+            open_time=trade.open_time,
+            close_time=trade.close_time,
+            open_price=trade.open_price,
+            close_price=trade.close_price,
+            total_commission=trade.total_commission,
+            profit_loss=trade.profit_loss,
+            currency=trade.currency,
+        )
+        session.add(parent)
+        parent_models.append((trade.fill_indexes, parent))
+
+    await session.flush()
+
+    parent_id_lookup: dict[int, int] = {}
+    for fill_indexes, parent in parent_models:
+        for fill_index in fill_indexes:
+            parent_id_lookup[fill_index] = parent.id
+
+    for idx, fill in enumerate(fills):
+        asset = await get_asset(fill.asset_code, fill.asset_type, fill.timezone, fill.exchange)
+        trade_fill = TradeFill(
+            parent_trade_id=parent_id_lookup.get(idx),
+            asset_id=asset.id,
+            side=fill.side,
+            quantity=fill.quantity,
+            price=fill.price,
+            commission=fill.commission,
+            currency=fill.currency,
+            trade_time=fill.trade_time,
+            source=fill.source,
+            order_id=fill.order_id,
+            import_batch_id=batch.id,
+        )
+        session.add(trade_fill)
+
+    batch.status = ImportStatus.COMPLETED
+    batch.completed_at = datetime.utcnow()
+
+    return batch

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> asyncio.AbstractEventLoop:  # type: ignore[override]
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture()
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(TEST_DB_URL, future=True)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture()
+def mock_csv_bytes() -> bytes:
+    csv_path = Path(__file__).resolve().parents[3] / "mock" / "TradeNote.csv"
+    return csv_path.read_bytes()

--- a/backend/app/tests/test_importer.py
+++ b/backend/app/tests/test_importer.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.models import ImportBatch, ParentTrade, TradeFill
+from app.services.ibkr_importer import import_ibkr_csv
+
+
+@pytest.mark.asyncio
+async def test_import_ibkr_csv(async_session, mock_csv_bytes) -> None:
+    batch = await import_ibkr_csv(async_session, mock_csv_bytes, "TradeNote.csv")
+    await async_session.commit()
+
+    assert batch.status.name == "COMPLETED"
+    fills_result = await async_session.execute(select(TradeFill))
+    fills = fills_result.scalars().all()
+    trades_result = await async_session.execute(select(ParentTrade))
+    trades = trades_result.scalars().all()
+    batch_result = await async_session.execute(select(ImportBatch))
+    batches = batch_result.scalars().all()
+
+    assert len(fills) > 0
+    assert len(trades) > 0
+    assert len(batches) == 1
+
+    first_fill = fills[0]
+    assert first_fill.trade_time.tzinfo is not None
+    assert first_fill.trade_time.utcoffset() == timezone.utc.utcoffset(first_fill.trade_time)
+
+    # Parent trades should link to fills
+    parent_fill_counts = {trade.id: 0 for trade in trades}
+    for fill in fills:
+        assert fill.parent_trade_id is not None
+        parent_fill_counts[fill.parent_trade_id] += 1
+    assert all(count > 0 for count in parent_fill_counts.values())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,11 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+sqlalchemy==2.0.25
+asyncpg==0.29.0
+pydantic-settings==2.1.0
+python-multipart==0.0.9
+alembic==1.12.1
+pytest==7.4.4
+pytest-asyncio==0.23.2
+httpx==0.26.0
+tzdata==2024.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: tradej
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/tradej
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trade Journal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tradej-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.7",
+    "antd": "^5.13.0",
+    "axios": "^1.6.7",
+    "dayjs": "^1.11.10",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.25",
+    "@types/react-dom": "^18.2.11",
+    "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
+import AppLayout from "./components/AppLayout";
+import CalendarPage from "./pages/CalendarPage";
+import Dashboard from "./pages/Dashboard";
+import ImportPage from "./pages/ImportPage";
+import Trades from "./pages/Trades";
+
+const App = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<AppLayout />}>
+          <Route index element={<Dashboard />} />
+          <Route path="trades" element={<Trades />} />
+          <Route path="calendar" element={<CalendarPage />} />
+          <Route path="imports" element={<ImportPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default App;

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,0 +1,16 @@
+import client from "./client";
+import { CalendarDay } from "../types";
+
+export interface CalendarQuery {
+  year: number;
+  month: number;
+  assetCode?: string | null;
+  assetType?: string | null;
+  direction?: string | null;
+  timezone?: string;
+}
+
+export const fetchCalendar = async (params: CalendarQuery): Promise<CalendarDay[]> => {
+  const response = await client.get<CalendarDay[]>("/calendar", { params });
+  return response.data;
+};

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const client = axios.create({
+  baseURL: "/api",
+  timeout: 15000
+});
+
+export default client;

--- a/frontend/src/api/imports.ts
+++ b/frontend/src/api/imports.ts
@@ -1,0 +1,17 @@
+import client from "./client";
+import { ImportBatch } from "../types";
+
+export const listImports = async (): Promise<ImportBatch[]> => {
+  const response = await client.get<ImportBatch[]>("/imports");
+  return response.data;
+};
+
+export const uploadIbkrCsv = async (file: File): Promise<ImportBatch> => {
+  const formData = new FormData();
+  formData.append("broker", "ibkr");
+  formData.append("file", file);
+  const response = await client.post<ImportBatch>("/imports", formData, {
+    headers: { "Content-Type": "multipart/form-data" }
+  });
+  return response.data;
+};

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,12 @@
+import client from "./client";
+import { Settings } from "../types";
+
+export const fetchSettings = async (): Promise<Settings> => {
+  const response = await client.get<Settings>("/settings");
+  return response.data;
+};
+
+export const updateSettings = async (settings: Settings): Promise<Settings> => {
+  const response = await client.patch<Settings>("/settings", settings);
+  return response.data;
+};

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -1,0 +1,13 @@
+import client from "./client";
+import { AssetBreakdown, OverviewStats } from "../types";
+import { TradeQuery } from "./trades";
+
+export const fetchOverviewStats = async (params: TradeQuery): Promise<OverviewStats> => {
+  const response = await client.get<OverviewStats>("/stats/overview", { params });
+  return response.data;
+};
+
+export const fetchAssetBreakdown = async (params: TradeQuery): Promise<AssetBreakdown[]> => {
+  const response = await client.get<AssetBreakdown[]>("/stats/by-asset", { params });
+  return response.data;
+};

--- a/frontend/src/api/trades.ts
+++ b/frontend/src/api/trades.ts
@@ -1,0 +1,28 @@
+import client from "./client";
+import { ParentTrade } from "../types";
+
+export interface TradeQuery {
+  assetCode?: string | null;
+  assetType?: string | null;
+  direction?: string | null;
+  start?: string | null;
+  end?: string | null;
+  timezone?: string;
+}
+
+export const fetchTrades = async (params: TradeQuery): Promise<ParentTrade[]> => {
+  const response = await client.get<ParentTrade[]>("/trades", { params });
+  return response.data;
+};
+
+export const deleteAllTrades = async (): Promise<void> => {
+  await client.delete("/trades");
+};
+
+export const exportFills = async (params: TradeQuery): Promise<string> => {
+  const response = await client.get("/trades/fills/export", {
+    params,
+    responseType: "text"
+  });
+  return response.data as string;
+};

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,0 +1,51 @@
+import { Layout, Menu, Typography } from "antd";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+
+import TimezoneSelector from "./TimezoneSelector";
+
+const { Header, Content, Footer } = Layout;
+
+const menuItems = [
+  { key: "/", label: "仪表盘" },
+  { key: "/trades", label: "交易记录" },
+  { key: "/calendar", label: "交易日历" },
+  { key: "/imports", label: "数据导入" }
+];
+
+const AppLayout = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleMenuClick = ({ key }: { key: string }) => {
+    navigate(key);
+  };
+
+  const activeKey = menuItems.find((item) =>
+    item.key === "/" ? location.pathname === "/" : location.pathname.startsWith(item.key)
+  )?.key ?? "/";
+
+  return (
+    <Layout style={{ minHeight: "100vh" }}>
+      <Header style={{ display: "flex", alignItems: "center", gap: 16 }}>
+        <Typography.Title level={4} style={{ color: "#fff", margin: 0 }}>
+          交易日志
+        </Typography.Title>
+        <Menu
+          theme="dark"
+          mode="horizontal"
+          selectedKeys={[activeKey]}
+          items={menuItems}
+          onClick={handleMenuClick}
+          style={{ flex: 1 }}
+        />
+        <TimezoneSelector />
+      </Header>
+      <Content style={{ padding: "24px" }}>
+        <Outlet />
+      </Content>
+      <Footer style={{ textAlign: "center" }}>Trade Journal © {new Date().getFullYear()}</Footer>
+    </Layout>
+  );
+};
+
+export default AppLayout;

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,141 @@
+import { useEffect } from "react";
+import { Card, Col, DatePicker, Input, Row, Select, Space, Button } from "antd";
+import dayjs from "dayjs";
+
+import { useAppDispatch, useAppSelector } from "../hooks";
+import {
+  resetFilters,
+  setAssetCode,
+  setAssetType,
+  setDateRange,
+  setDirection,
+  setPreset
+} from "../store/filterSlice";
+import { AssetType, DateRangePreset, TradeDirection } from "../types";
+import { computeRange } from "../utils/date";
+
+const presetOptions: { label: string; value: DateRangePreset }[] = [
+  { label: "今天", value: "today" },
+  { label: "昨天", value: "yesterday" },
+  { label: "本周", value: "thisWeek" },
+  { label: "本月", value: "thisMonth" },
+  { label: "本季度", value: "thisQuarter" },
+  { label: "本年", value: "thisYear" },
+  { label: "最近7天", value: "last7" },
+  { label: "最近30天", value: "last30" },
+  { label: "最近一年", value: "last365" }
+];
+
+const assetTypeOptions: { label: string; value: AssetType }[] = [
+  { label: "股票", value: "stock" },
+  { label: "期权", value: "option" },
+  { label: "期货", value: "future" }
+];
+
+const directionOptions: { label: string; value: TradeDirection }[] = [
+  { label: "多头", value: "long" },
+  { label: "空头", value: "short" }
+];
+
+const FilterBar = () => {
+  const dispatch = useAppDispatch();
+  const filters = useAppSelector((state) => state.filters);
+  const timezone = useAppSelector((state) => state.settings.timezone);
+
+  useEffect(() => {
+    if (filters.preset) {
+      const range = computeRange(filters.preset, timezone);
+      if (filters.startDate !== range.start || filters.endDate !== range.end) {
+        dispatch(setDateRange({ startDate: range.start, endDate: range.end }));
+      }
+    }
+  }, [dispatch, filters.endDate, filters.preset, filters.startDate, timezone]);
+
+  const handleRangeChange = (values: [dayjs.Dayjs | null, dayjs.Dayjs | null] | null) => {
+    if (!values || !values[0] || !values[1]) {
+      dispatch(setDateRange({ startDate: null, endDate: null }));
+      dispatch(setPreset(null));
+      return;
+    }
+    dispatch(
+      setDateRange({
+        startDate: values[0].tz(timezone).startOf("day").toISOString(),
+        endDate: values[1].tz(timezone).endOf("day").toISOString()
+      })
+    );
+    dispatch(setPreset(null));
+  };
+
+  const handlePresetChange = (value: DateRangePreset) => {
+    dispatch(setPreset(value));
+  };
+
+  const handleReset = () => {
+    dispatch(resetFilters());
+  };
+
+  const rangeValue =
+    filters.startDate && filters.endDate
+      ? [dayjs(filters.startDate), dayjs(filters.endDate)]
+      : null;
+
+  return (
+    <Card size="small" style={{ marginBottom: 16 }}>
+      <Row gutter={16} align="middle">
+        <Col xs={24} md={6} lg={4}>
+          <Input
+            value={filters.assetCode ?? ""}
+            onChange={(e) => dispatch(setAssetCode(e.target.value.toUpperCase() || null))}
+            placeholder="资产代码"
+            allowClear
+          />
+        </Col>
+        <Col xs={24} md={6} lg={4}>
+          <Select
+            value={filters.assetType ?? undefined}
+            placeholder="资产类型"
+            allowClear
+            style={{ width: "100%" }}
+            onChange={(value) => dispatch(setAssetType((value as AssetType) || null))}
+            options={assetTypeOptions}
+          />
+        </Col>
+        <Col xs={24} md={6} lg={4}>
+          <Select
+            value={filters.direction ?? undefined}
+            placeholder="方向"
+            allowClear
+            style={{ width: "100%" }}
+            onChange={(value) => dispatch(setDirection((value as TradeDirection) || null))}
+            options={directionOptions}
+          />
+        </Col>
+        <Col xs={24} md={12} lg={6}>
+          <DatePicker.RangePicker
+            value={rangeValue as any}
+            onChange={handleRangeChange as any}
+            style={{ width: "100%" }}
+            allowClear
+          />
+        </Col>
+        <Col xs={24} md={8} lg={4}>
+          <Select
+            value={filters.preset ?? undefined}
+            placeholder="快捷选择"
+            allowClear
+            style={{ width: "100%" }}
+            onChange={handlePresetChange}
+            options={presetOptions}
+          />
+        </Col>
+        <Col xs={24} md={4} lg={2}>
+          <Space>
+            <Button onClick={handleReset}>重置</Button>
+          </Space>
+        </Col>
+      </Row>
+    </Card>
+  );
+};
+
+export default FilterBar;

--- a/frontend/src/components/TimezoneSelector.tsx
+++ b/frontend/src/components/TimezoneSelector.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from "react";
+import { Select, message } from "antd";
+
+import { useAppDispatch, useAppSelector } from "../hooks";
+import { hydrateSettings, setTimezone } from "../store/settingsSlice";
+import { fetchSettings, updateSettings } from "../api/settings";
+
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Paris",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Australia/Sydney"
+];
+
+const resolveTimezones = (): string[] => {
+  if (typeof Intl.supportedValuesOf === "function") {
+    try {
+      return Intl.supportedValuesOf("timeZone");
+    } catch (error) {
+      console.warn("Unable to load timezones from Intl", error);
+    }
+  }
+  return FALLBACK_TIMEZONES;
+};
+
+const TimezoneSelector = () => {
+  const dispatch = useAppDispatch();
+  const timezone = useAppSelector((state) => state.settings.timezone);
+  const [loading, setLoading] = useState(false);
+  const options = useMemo(() => resolveTimezones(), []);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const settings = await fetchSettings();
+        dispatch(hydrateSettings(settings));
+      } catch (error) {
+        console.error("Failed to load settings", error);
+      }
+    };
+    void load();
+  }, [dispatch]);
+
+  const handleChange = async (value: string) => {
+    dispatch(setTimezone(value));
+    setLoading(true);
+    try {
+      await updateSettings({ timezone: value });
+      message.success("时区已更新");
+    } catch (error) {
+      console.error(error);
+      message.error("更新时区失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Select
+      showSearch
+      size="middle"
+      style={{ width: 220 }}
+      value={timezone}
+      loading={loading}
+      onChange={handleChange}
+      filterOption={(input, option) => (option?.value ?? "").toLowerCase().includes(input.toLowerCase())}
+    >
+      {options.map((tz) => (
+        <Select.Option key={tz} value={tz}>
+          {tz}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+export default TimezoneSelector;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+
+import type { AppDispatch, RootState } from "../store";
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Provider } from "react-redux";
+import { ConfigProvider } from "antd";
+
+import App from "./App";
+import { store } from "./store";
+
+import "antd/dist/reset.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <ConfigProvider theme={{ token: { colorPrimary: "#1677ff" } }}>
+        <App />
+      </ConfigProvider>
+    </Provider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from "react";
+import { Calendar, Card, Popover, Typography } from "antd";
+import dayjs, { Dayjs } from "dayjs";
+
+import { fetchCalendar } from "../api/calendar";
+import FilterBar from "../components/FilterBar";
+import { useAppDispatch, useAppSelector } from "../hooks";
+import { setDateRange, setPreset } from "../store/filterSlice";
+import { CalendarDay } from "../types";
+import { formatCurrency } from "../utils/date";
+import { useNavigate } from "react-router-dom";
+
+const CalendarPage = () => {
+  const dispatch = useAppDispatch();
+  const filters = useAppSelector((state) => state.filters);
+  const timezone = useAppSelector((state) => state.settings.timezone);
+  const [value, setValue] = useState<Dayjs>(dayjs());
+  const [data, setData] = useState<Record<string, CalendarDay>>({});
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const query = useMemo(
+    () => ({
+      assetCode: filters.assetCode,
+      assetType: filters.assetType,
+      direction: filters.direction
+    }),
+    [filters.assetCode, filters.assetType, filters.direction]
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const response = await fetchCalendar({
+          year: value.year(),
+          month: value.month() + 1,
+          timezone,
+          ...query
+        });
+        const bucket: Record<string, CalendarDay> = {};
+        response.forEach((item) => {
+          bucket[item.date] = item;
+        });
+        setData(bucket);
+      } catch (error) {
+        console.error("Failed to load calendar", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [query, timezone, value]);
+
+  const dateCellRender = (current: Dayjs) => {
+    const key = current.format("YYYY-MM-DD");
+    const entry = data[key];
+    if (!entry) {
+      return <div className="calendar-cell-empty" />;
+    }
+    const content = (
+      <div>
+        <Typography.Text>交易笔数：{entry.trade_count}</Typography.Text>
+        <br />
+        <Typography.Text>总盈亏：{formatCurrency(entry.total_profit_loss)}</Typography.Text>
+      </div>
+    );
+    const isPositive = entry.total_profit_loss >= 0;
+    return (
+      <Popover content={content} title={key} placement="top">
+        <div
+          style={{
+            background: isPositive ? "#f6ffed" : "#fff1f0",
+            borderRadius: 6,
+            padding: 8,
+            textAlign: "center"
+          }}
+        >
+          <Typography.Text strong>{entry.trade_count}</Typography.Text>
+          <br />
+          <Typography.Text type={isPositive ? "success" : "danger"}>
+            {entry.total_profit_loss.toFixed(2)}
+          </Typography.Text>
+        </div>
+      </Popover>
+    );
+  };
+
+  const handleSelect = (date: Dayjs) => {
+    const start = date.startOf("day").toISOString();
+    const end = date.endOf("day").toISOString();
+    dispatch(setDateRange({ startDate: start, endDate: end }));
+    dispatch(setPreset(null));
+    navigate("/trades");
+  };
+
+  return (
+    <div>
+      <FilterBar />
+      <Card loading={loading}>
+        <Calendar
+          value={value}
+          onSelect={handleSelect}
+          onPanelChange={(next) => {
+            setValue(next);
+          }}
+          dateFullCellRender={dateCellRender}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default CalendarPage;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, Col, Row, Statistic, Table } from "antd";
+
+import FilterBar from "../components/FilterBar";
+import { fetchAssetBreakdown, fetchOverviewStats } from "../api/stats";
+import { useAppSelector } from "../hooks";
+import { AssetBreakdown, OverviewStats } from "../types";
+import { formatCurrency, formatPercentage } from "../utils/date";
+
+const Dashboard = () => {
+  const filters = useAppSelector((state) => state.filters);
+  const timezone = useAppSelector((state) => state.settings.timezone);
+  const [overview, setOverview] = useState<OverviewStats | null>(null);
+  const [breakdown, setBreakdown] = useState<AssetBreakdown[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const query = useMemo(
+    () => ({
+      assetCode: filters.assetCode,
+      assetType: filters.assetType,
+      direction: filters.direction,
+      start: filters.startDate,
+      end: filters.endDate,
+      timezone
+    }),
+    [filters.assetCode, filters.assetType, filters.direction, filters.startDate, filters.endDate, timezone]
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [overviewResp, breakdownResp] = await Promise.all([
+          fetchOverviewStats(query),
+          fetchAssetBreakdown(query)
+        ]);
+        setOverview(overviewResp);
+        setBreakdown(breakdownResp);
+      } catch (error) {
+        console.error("Failed to load dashboard data", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [query]);
+
+  return (
+    <div>
+      <FilterBar />
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic title="交易总数" value={overview?.total_trades ?? 0} />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic title="胜率" value={formatPercentage(overview?.win_rate ?? 0)} />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic title="总盈亏" value={formatCurrency(overview?.total_profit_loss ?? 0)} />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic title="平均盈亏" value={formatCurrency(overview?.average_profit_loss ?? 0)} />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic
+              title="盈亏比"
+              value={overview?.profit_loss_ratio ? overview.profit_loss_ratio.toFixed(2) : "--"}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} md={8}>
+          <Card loading={loading}>
+            <Statistic
+              title="盈利因子"
+              value={overview?.profit_factor ? overview.profit_factor.toFixed(2) : "--"}
+            />
+          </Card>
+        </Col>
+      </Row>
+      <Card title="按资产分类统计" style={{ marginTop: 24 }} loading={loading}>
+        <Table
+          dataSource={breakdown}
+          rowKey={(record) => record.asset_code}
+          pagination={false}
+          columns={[
+            {
+              title: "资产代码",
+              dataIndex: "asset_code"
+            },
+            {
+              title: "资产类型",
+              dataIndex: "asset_type"
+            },
+            {
+              title: "交易次数",
+              dataIndex: "trade_count"
+            },
+            {
+              title: "胜率",
+              dataIndex: "win_rate",
+              render: (value: number) => formatPercentage(value)
+            },
+            {
+              title: "总盈亏",
+              dataIndex: "total_profit_loss",
+              render: (value: number) => formatCurrency(value)
+            }
+          ]}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useState } from "react";
+import { Card, Table, Upload, message } from "antd";
+import type { UploadProps } from "antd";
+
+import { listImports, uploadIbkrCsv } from "../api/imports";
+import { ImportBatch } from "../types";
+import { formatDateTime } from "../utils/date";
+import { useAppSelector } from "../hooks";
+
+const ImportPage = () => {
+  const timezone = useAppSelector((state) => state.settings.timezone);
+  const [records, setRecords] = useState<ImportBatch[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await listImports();
+      setRecords(data);
+    } catch (error) {
+      console.error("Failed to load imports", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const uploadProps: UploadProps = {
+    name: "file",
+    accept: ".csv",
+    showUploadList: false,
+    customRequest: async ({ file, onError, onSuccess }) => {
+      try {
+        await uploadIbkrCsv(file as File);
+        message.success("上传成功");
+        await loadData();
+        onSuccess?.("ok", file as any);
+      } catch (error) {
+        console.error(error);
+        message.error("上传失败");
+        onError?.(error as Error);
+      }
+    }
+  };
+
+  return (
+    <div>
+      <Card title="导入IBKR CSV">
+        <Upload {...uploadProps}>
+          <div style={{ padding: 24, border: "1px dashed #d9d9d9", borderRadius: 8, textAlign: "center" }}>
+            点击或拖拽文件到此处上传
+          </div>
+        </Upload>
+      </Card>
+      <Card title="导入历史" style={{ marginTop: 24 }} loading={loading}>
+        <Table
+          dataSource={records}
+          rowKey={(record) => record.id}
+          pagination={false}
+          columns={[
+            { title: "编号", dataIndex: "id" },
+            { title: "文件名", dataIndex: "filename" },
+            { title: "券商", dataIndex: "broker" },
+            { title: "状态", dataIndex: "status" },
+            { title: "总记录数", dataIndex: "total_records" },
+            {
+              title: "创建时间",
+              dataIndex: "created_at",
+              render: (value: string) => formatDateTime(value, timezone)
+            },
+            {
+              title: "完成时间",
+              dataIndex: "completed_at",
+              render: (value: string | null) => (value ? formatDateTime(value, timezone) : "--")
+            },
+            {
+              title: "错误信息",
+              dataIndex: "error_message",
+              render: (value: string | null) => value ?? "--"
+            }
+          ]}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default ImportPage;

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Card, Popconfirm, Space, Table, message } from "antd";
+
+import FilterBar from "../components/FilterBar";
+import { deleteAllTrades, exportFills, fetchTrades } from "../api/trades";
+import { useAppSelector } from "../hooks";
+import { ParentTrade, TradeFill } from "../types";
+import { formatCurrency, formatDateTime } from "../utils/date";
+
+const Trades = () => {
+  const filters = useAppSelector((state) => state.filters);
+  const timezone = useAppSelector((state) => state.settings.timezone);
+  const [trades, setTrades] = useState<ParentTrade[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const query = useMemo(
+    () => ({
+      assetCode: filters.assetCode,
+      assetType: filters.assetType,
+      direction: filters.direction,
+      start: filters.startDate,
+      end: filters.endDate,
+      timezone
+    }),
+    [filters.assetCode, filters.assetType, filters.direction, filters.startDate, filters.endDate, timezone]
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchTrades(query);
+        setTrades(data);
+      } catch (error) {
+        console.error("Failed to load trades", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [query]);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const content = await exportFills(query);
+      const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "trade_fills.pine";
+      anchor.click();
+      URL.revokeObjectURL(url);
+      message.success("导出成功");
+    } catch (error) {
+      console.error(error);
+      message.error("导出失败");
+    } finally {
+      setExporting(false);
+    }
+  }, [query]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    try {
+      await deleteAllTrades();
+      setTrades([]);
+      message.success("所有交易已删除");
+    } catch (error) {
+      console.error(error);
+      message.error("删除失败");
+    } finally {
+      setDeleting(false);
+    }
+  }, []);
+
+  const renderFillTable = (fills: TradeFill[]) => (
+    <Table
+      dataSource={fills}
+      rowKey={(fill) => fill.id}
+      pagination={false}
+      size="small"
+      columns={[
+        { title: "方向", dataIndex: "side" },
+        { title: "数量", dataIndex: "quantity" },
+        { title: "价格", dataIndex: "price", render: (value: number) => value.toFixed(2) },
+        { title: "佣金", dataIndex: "commission", render: (value: number) => value.toFixed(2) },
+        {
+          title: "成交时间",
+          dataIndex: "trade_time",
+          render: (value: string) => formatDateTime(value, timezone)
+        },
+        { title: "来源", dataIndex: "source", render: (value: string | null) => value ?? "--" },
+        { title: "订单号", dataIndex: "order_id", render: (value: string | null) => value ?? "--" }
+      ]}
+    />
+  );
+
+  return (
+    <div>
+      <Space style={{ width: "100%", marginBottom: 16, justifyContent: "space-between" }}>
+        <Space>
+          <Button type="primary" onClick={handleExport} loading={exporting}>
+            导出子交易
+          </Button>
+          <Popconfirm title="确认删除所有交易？" onConfirm={handleDelete} okButtonProps={{ loading: deleting }}>
+            <Button danger>删除所有交易</Button>
+          </Popconfirm>
+        </Space>
+      </Space>
+      <FilterBar />
+      <Card>
+        <Table
+          loading={loading}
+          dataSource={trades}
+          rowKey={(trade) => trade.id}
+          expandable={{ expandedRowRender: (record) => renderFillTable(record.fills) }}
+          columns={[
+            { title: "记录ID", dataIndex: "id" },
+            { title: "资产代码", dataIndex: "asset_code" },
+            { title: "方向", dataIndex: "direction" },
+            { title: "数量", dataIndex: "quantity" },
+            {
+              title: "开仓价格",
+              dataIndex: "open_price",
+              render: (value: number | null) => (value !== null ? value.toFixed(2) : "--")
+            },
+            {
+              title: "平仓价格",
+              dataIndex: "close_price",
+              render: (value: number | null) => (value !== null ? value.toFixed(2) : "--")
+            },
+            {
+              title: "开仓时间",
+              dataIndex: "open_time",
+              render: (value: string) => formatDateTime(value, timezone)
+            },
+            {
+              title: "平仓时间",
+              dataIndex: "close_time",
+              render: (value: string | null) => (value ? formatDateTime(value, timezone) : "--")
+            },
+            {
+              title: "佣金",
+              dataIndex: "total_commission",
+              render: (_: number, record: ParentTrade) => formatCurrency(record.total_commission, record.currency)
+            },
+            {
+              title: "盈亏",
+              dataIndex: "profit_loss",
+              render: (_: number, record: ParentTrade) => formatCurrency(record.profit_loss, record.currency)
+            }
+          ]}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default Trades;

--- a/frontend/src/store/filterSlice.ts
+++ b/frontend/src/store/filterSlice.ts
@@ -1,0 +1,46 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { AssetType, DateRangePreset, FilterState, TradeDirection } from "../types";
+
+type DateRangePayload = {
+  startDate: string | null;
+  endDate: string | null;
+};
+
+const initialState: FilterState = {
+  assetCode: null,
+  assetType: null,
+  direction: null,
+  startDate: null,
+  endDate: null,
+  preset: "last30"
+};
+
+const filterSlice = createSlice({
+  name: "filters",
+  initialState,
+  reducers: {
+    setAssetCode(state, action: PayloadAction<string | null>) {
+      state.assetCode = action.payload;
+    },
+    setAssetType(state, action: PayloadAction<AssetType | null>) {
+      state.assetType = action.payload;
+    },
+    setDirection(state, action: PayloadAction<TradeDirection | null>) {
+      state.direction = action.payload;
+    },
+    setDateRange(state, action: PayloadAction<DateRangePayload>) {
+      state.startDate = action.payload.startDate;
+      state.endDate = action.payload.endDate;
+    },
+    setPreset(state, action: PayloadAction<DateRangePreset>) {
+      state.preset = action.payload;
+    },
+    resetFilters() {
+      return initialState;
+    }
+  }
+});
+
+export const { setAssetCode, setAssetType, setDirection, setDateRange, setPreset, resetFilters } =
+  filterSlice.actions;
+export default filterSlice.reducer;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,14 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+import filterReducer from "./filterSlice";
+import settingsReducer from "./settingsSlice";
+
+export const store = configureStore({
+  reducer: {
+    filters: filterReducer,
+    settings: settingsReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/frontend/src/store/settingsSlice.ts
+++ b/frontend/src/store/settingsSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Settings } from "../types";
+
+interface SettingsState {
+  timezone: string;
+}
+
+const initialState: SettingsState = {
+  timezone: "UTC"
+};
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState,
+  reducers: {
+    setTimezone(state, action: PayloadAction<string>) {
+      state.timezone = action.payload;
+    },
+    hydrateSettings(state, action: PayloadAction<Settings>) {
+      state.timezone = action.payload.timezone;
+    }
+  }
+});
+
+export const { setTimezone, hydrateSettings } = settingsSlice.actions;
+export default settingsSlice.reducer;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,92 @@
+export type AssetType = "stock" | "option" | "future";
+export type TradeDirection = "long" | "short";
+export type FillSide = "BUY" | "SELL";
+
+export interface TradeFill {
+  id: number;
+  side: FillSide;
+  quantity: number;
+  price: number;
+  commission: number;
+  currency: string;
+  trade_time: string;
+  source?: string | null;
+  order_id?: string | null;
+}
+
+export interface ParentTrade {
+  id: number;
+  asset_id: number;
+  asset_code: string;
+  asset_type: AssetType;
+  direction: TradeDirection;
+  quantity: number;
+  open_time: string;
+  close_time: string | null;
+  open_price: number | null;
+  close_price: number | null;
+  total_commission: number;
+  profit_loss: number;
+  currency: string;
+  fills: TradeFill[];
+}
+
+export interface OverviewStats {
+  total_trades: number;
+  win_rate: number;
+  total_profit_loss: number;
+  average_profit_loss: number;
+  profit_loss_ratio: number | null;
+  profit_factor: number | null;
+}
+
+export interface AssetBreakdown {
+  asset_code: string;
+  asset_type: string;
+  trade_count: number;
+  win_rate: number;
+  total_profit_loss: number;
+}
+
+export interface CalendarDay {
+  date: string;
+  trade_count: number;
+  total_profit_loss: number;
+}
+
+export interface ImportBatch {
+  id: number;
+  broker: string;
+  filename: string;
+  status: string;
+  error_message?: string | null;
+  total_records: number;
+  created_at: string;
+  completed_at: string | null;
+  timezone: string | null;
+}
+
+export interface Settings {
+  timezone: string;
+}
+
+export type DateRangePreset =
+  | "today"
+  | "yesterday"
+  | "thisWeek"
+  | "thisMonth"
+  | "thisQuarter"
+  | "thisYear"
+  | "last7"
+  | "last30"
+  | "last365"
+  | null;
+
+export interface FilterState {
+  assetCode: string | null;
+  assetType: AssetType | null;
+  direction: TradeDirection | null;
+  startDate: string | null;
+  endDate: string | null;
+  preset: DateRangePreset;
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,80 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezonePlugin from "dayjs/plugin/timezone";
+
+import { DateRangePreset } from "../types";
+
+dayjs.extend(utc);
+dayjs.extend(timezonePlugin);
+
+export const computeRange = (preset: DateRangePreset, timezone: string): {
+  start: string | null;
+  end: string | null;
+} => {
+  if (!preset) {
+    return { start: null, end: null };
+  }
+  const now = dayjs().tz(timezone);
+  switch (preset) {
+    case "today": {
+      const start = now.startOf("day");
+      const end = now.endOf("day");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "yesterday": {
+      const start = now.subtract(1, "day").startOf("day");
+      const end = start.endOf("day");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "thisWeek": {
+      const start = now.startOf("week");
+      const end = now.endOf("week");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "thisMonth": {
+      const start = now.startOf("month");
+      const end = now.endOf("month");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "thisQuarter": {
+      const start = now.startOf("quarter");
+      const end = now.endOf("quarter");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "thisYear": {
+      const start = now.startOf("year");
+      const end = now.endOf("year");
+      return { start: start.toISOString(), end: end.toISOString() };
+    }
+    case "last7": {
+      const start = now.subtract(6, "day").startOf("day");
+      return { start: start.toISOString(), end: now.endOf("day").toISOString() };
+    }
+    case "last30": {
+      const start = now.subtract(29, "day").startOf("day");
+      return { start: start.toISOString(), end: now.endOf("day").toISOString() };
+    }
+    case "last365": {
+      const start = now.subtract(364, "day").startOf("day");
+      return { start: start.toISOString(), end: now.endOf("day").toISOString() };
+    }
+    default:
+      return { start: null, end: null };
+  }
+};
+
+export const formatCurrency = (value: number, currency = "USD"): string => {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2
+  }).format(value);
+};
+
+export const formatPercentage = (value: number): string => {
+  return `${(value * 100).toFixed(2)}%`;
+};
+
+export const formatDateTime = (value: string, timezone: string): string => {
+  return dayjs(value).tz(timezone).format("YYYY-MM-DD HH:mm");
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend with SQLAlchemy models, import service for IBKR CSV files, and REST endpoints for trades, stats, calendar, settings, and imports
- add trade aggregation logic, persistence, and pytest coverage for the CSV import pipeline
- create a Vite + React frontend with global filters, dashboard metrics, trade table with child fills, calendar view, data import page, and timezone selector plus Docker/Docker Compose setup

## Testing
- `pytest` *(fails: missing third-party dependencies because pip is blocked by the proxy)*
- `npm run build` *(fails: npm registry returns 403 so dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd80ac2870832a882635b94770e18d