### PR TITLE
Allow configuring frontend proxy target

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -29,6 +29,8 @@ A full-stack trade journal management system featuring a React + Vite frontend a
    ```bash
    cd frontend
    npm install
+   # optional: override the backend API target (defaults to http://localhost:8000)
+   # export VITE_PROXY_TARGET="http://localhost:8000"
    npm run dev
    ```
 
@@ -39,6 +41,9 @@ docker-compose up --build
 ```
 
 The backend will be accessible at `http://localhost:8000`, and the Vite dev server at `http://localhost:5173`.
+The frontend container forwards API calls to the backend using the `VITE_PROXY_TARGET`
+environment variable, which defaults to `http://localhost:8000` for local development and
+is automatically set to `http://backend:8000` inside Docker Compose.
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     build: ./frontend
     depends_on:
       - backend
+    environment:
+      - VITE_PROXY_TARGET=http://backend:8000
     ports:
       - "5173:5173"
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,20 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      "/api": {
-        target: "http://localhost:8000",
-        changeOrigin: true
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget = env.VITE_PROXY_TARGET ?? "http://localhost:8000";
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        "/api": {
+          target: proxyTarget,
+          changeOrigin: true
+        }
       }
     }
-  }
+  };
 });


### PR DESCRIPTION
## Summary
- allow configuring the Vite dev server proxy target through the VITE_PROXY_TARGET environment variable
- set the frontend container's proxy target to the backend service when using docker-compose
- document how to override the proxy target for local development

## Testing
- npm install *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8d1bba8c832ab35cf41d6f004651