### PR TITLE
Adjust calendar filters and export script

### DIFF
--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -4,8 +4,8 @@ import { CalendarDay } from "../types";
 export interface CalendarQuery {
   year: number;
   month: number;
-  assetCode?: string | null;
-  assetType?: string | null;
+  asset_code?: string | null;
+  asset_type?: string | null;
   direction?: string | null;
   timezone?: string;
   currency?: string;

--- a/frontend/src/api/trades.ts
+++ b/frontend/src/api/trades.ts
@@ -2,8 +2,8 @@ import client from "./client";
 import { ParentTrade } from "../types";
 
 export interface TradeQuery {
-  assetCode?: string | null;
-  assetType?: string | null;
+  asset_code?: string | null;
+  asset_type?: string | null;
   direction?: string | null;
   start?: string | null;
   end?: string | null;

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -8,7 +8,7 @@ import FilterBar from "../components/FilterBar";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { setDateRange, setPreset } from "../store/filterSlice";
 import { CalendarDay } from "../types";
-import { formatCurrency, formatPercentage } from "../utils/date";
+import { formatPercentage } from "../utils/date";
 import { useNavigate } from "react-router-dom";
 
 const CalendarPage = () => {
@@ -24,8 +24,8 @@ const CalendarPage = () => {
 
   const query = useMemo(
     () => ({
-      assetCode: filters.assetCode,
-      assetType: filters.assetType,
+      asset_code: filters.assetCode,
+      asset_type: filters.assetType,
       direction: filters.direction
     }),
     [filters.assetCode, filters.assetType, filters.direction]
@@ -66,27 +66,36 @@ const CalendarPage = () => {
     const entry = data[key];
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
+    const tradeCountText = `${entry?.trade_count ?? 0}笔`;
+    const winRateText = entry ? formatPercentage(entry.win_rate) : "0.00%";
+    const profitLoss = entry?.total_profit_loss ?? 0;
+    const profitText = new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(profitLoss);
+
     return (
       <div
         style={{
           minHeight: 110,
           display: "flex",
           flexDirection: "column",
-          justifyContent: "space-between",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 6,
           borderRadius: 8,
           padding: 8,
+          textAlign: "center",
           background: entry ? (isPositive ? "#f6ffed" : "#fff1f0") : undefined
         }}
       >
-        <Typography.Text strong style={{ fontSize: 16 }}>
+        <Typography.Text strong style={{ fontSize: 21 }}>
           {current.date()}
         </Typography.Text>
-        <Typography.Text>交易笔数：{entry?.trade_count ?? 0}</Typography.Text>
-        <Typography.Text>
-          胜率：{entry ? formatPercentage(entry.win_rate) : "0.00%"}
-        </Typography.Text>
+        <Typography.Text>{tradeCountText}</Typography.Text>
+        <Typography.Text>{winRateText}</Typography.Text>
         <Typography.Text style={{ color: isPositive ? "#3f8600" : "#cf1322" }}>
-          总盈亏：{formatCurrency(entry?.total_profit_loss ?? 0, currency)}
+          {profitText}
         </Typography.Text>
       </div>
     );
@@ -100,6 +109,14 @@ const CalendarPage = () => {
     const entry = data[key];
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
+    const tradeCountText = `${entry?.trade_count ?? 0}笔`;
+    const winRateText = entry ? formatPercentage(entry.win_rate) : "0.00%";
+    const profitLoss = entry?.total_profit_loss ?? 0;
+    const profitText = new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(profitLoss);
+
     return (
       <div
         style={{
@@ -108,30 +125,40 @@ const CalendarPage = () => {
           padding: 12,
           display: "flex",
           flexDirection: "column",
-          gap: 4,
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 8,
+          textAlign: "center",
           background: entry ? (isPositive ? "#f6ffed" : "#fff1f0") : undefined
         }}
       >
-        <Typography.Text strong style={{ fontSize: 16 }}>
+        <Typography.Text strong style={{ fontSize: 21 }}>
           {current.format("MM月")}
         </Typography.Text>
-        <Typography.Text>交易笔数：{entry?.trade_count ?? 0}</Typography.Text>
-        <Typography.Text>
-          胜率：{entry ? formatPercentage(entry.win_rate) : "0.00%"}
-        </Typography.Text>
+        <Typography.Text>{tradeCountText}</Typography.Text>
+        <Typography.Text>{winRateText}</Typography.Text>
         <Typography.Text style={{ color: isPositive ? "#3f8600" : "#cf1322" }}>
-          总盈亏：{formatCurrency(entry?.total_profit_loss ?? 0, currency)}
+          {profitText}
         </Typography.Text>
       </div>
     );
   };
 
-  const handleSelect = (date: Dayjs) => {
-    if (mode === "year") {
-      setValue(date);
+  const handleSelect = (
+    date: Dayjs,
+    info: { source: "year" | "month" | "date" | "customize" }
+  ) => {
+    setValue(date);
+
+    if (mode === "year" && info.source === "month") {
       setMode("month");
       return;
     }
+
+    if (info.source !== "date") {
+      return;
+    }
+
     const start = date.startOf("day").toISOString();
     const end = date.endOf("day").toISOString();
     dispatch(setDateRange({ startDate: start, endDate: end }));

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,8 +17,8 @@ const Dashboard = () => {
 
   const query = useMemo(
     () => ({
-      assetCode: filters.assetCode,
-      assetType: filters.assetType,
+      asset_code: filters.assetCode,
+      asset_type: filters.assetType,
       direction: filters.direction,
       start: filters.startDate,
       end: filters.endDate,

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -18,8 +18,8 @@ const Trades = () => {
 
   const query = useMemo(
     () => ({
-      assetCode: filters.assetCode,
-      assetType: filters.assetType,
+      asset_code: filters.assetCode,
+      asset_type: filters.assetType,
       direction: filters.direction,
       start: filters.startDate,
       end: filters.endDate,


### PR DESCRIPTION
## Summary
- simplify calendar cell content, center align text, and avoid navigating away when only changing calendar panels
- send filter parameters in snake_case so dashboard, trades, and calendar queries refresh correctly
- rewrite the Pine script export to push up to 100 fills into an array with corrected bar alignment and timezone handling

## Testing
- npm install *(fails: registry access returns 403)*
- pip install -r backend/requirements.txt *(fails: proxy blocks access to package index)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9b6725f4832ab8b43328bf77406c