### PR TITLE
Update trade displays and calendar interactions

### DIFF
--- a/backend/app/api/routes/trades.py
+++ b/backend/app/api/routes/trades.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import get_db
-from app.core.currency import convert_amount, normalize_currency
+from app.core.currency import normalize_currency
 from app.models import Asset, AssetType, ParentTrade, TradeFill
 from app.models.trade import FillSide, TradeDirection
 from app.schemas.trade import ParentTradeWithFills, TradeFillBase
@@ -27,23 +27,17 @@ def _parse_datetime(dt: datetime | None, timezone: str) -> datetime | None:
     return dt.astimezone(ZoneInfo("UTC"))
 
 
-def _serialize_trade(trade: ParentTrade, target_currency: str | None = None) -> ParentTradeWithFills:
+def _serialize_trade(trade: ParentTrade) -> ParentTradeWithFills:
     original_currency = normalize_currency(trade.currency)
-    display_currency = normalize_currency(target_currency) if target_currency else original_currency
-
-    def convert_trade_value(value: float | None) -> float | None:
-        if value is None:
-            return None
-        return float(convert_amount(value, original_currency, display_currency))
 
     fills = [
         TradeFillBase(
             id=fill.id,
             side=fill.side,
             quantity=float(fill.quantity),
-            price=float(convert_amount(fill.price, fill.currency, display_currency)),
-            commission=float(convert_amount(fill.commission, fill.currency, display_currency)),
-            currency=display_currency,
+            price=float(fill.price),
+            commission=float(fill.commission),
+            currency=normalize_currency(fill.currency),
             original_currency=normalize_currency(fill.currency),
             trade_time=fill.trade_time,
             source=fill.source,
@@ -60,11 +54,11 @@ def _serialize_trade(trade: ParentTrade, target_currency: str | None = None) -> 
         quantity=float(trade.quantity),
         open_time=trade.open_time,
         close_time=trade.close_time,
-        open_price=convert_trade_value(float(trade.open_price)) if trade.open_price is not None else None,
-        close_price=convert_trade_value(float(trade.close_price)) if trade.close_price is not None else None,
-        total_commission=float(convert_amount(trade.total_commission, original_currency, display_currency)),
-        profit_loss=float(convert_amount(trade.profit_loss, original_currency, display_currency)),
-        currency=display_currency,
+        open_price=float(trade.open_price) if trade.open_price is not None else None,
+        close_price=float(trade.close_price) if trade.close_price is not None else None,
+        total_commission=float(trade.total_commission),
+        profit_loss=float(trade.profit_loss),
+        currency=original_currency,
         original_currency=original_currency,
         fills=fills,
     )
@@ -79,7 +73,6 @@ async def list_trades(
     end: datetime | None = Query(default=None),
     timezone: str = Query(default="UTC"),
     db: AsyncSession = Depends(get_db),
-    currency: str | None = Query(default=None),
 ) -> list[ParentTradeWithFills]:
     start_utc = _parse_datetime(start, timezone)
     end_utc = _parse_datetime(end, timezone)
@@ -108,8 +101,18 @@ async def list_trades(
 
     result = await db.execute(stmt)
     trades = result.scalars().unique().all()
-    target_currency = normalize_currency(currency) if currency else None
-    return [_serialize_trade(trade, target_currency) for trade in trades]
+    return [_serialize_trade(trade) for trade in trades]
+
+
+@router.delete("/{trade_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_trade(trade_id: int, db: AsyncSession = Depends(get_db)) -> Response:
+    trade = await db.get(ParentTrade, trade_id)
+    if trade is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trade not found")
+
+    await db.delete(trade)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete("", status_code=status.HTTP_204_NO_CONTENT)

--- a/frontend/src/api/trades.ts
+++ b/frontend/src/api/trades.ts
@@ -20,6 +20,10 @@ export const deleteAllTrades = async (): Promise<void> => {
   await client.delete("/trades");
 };
 
+export const deleteTrade = async (tradeId: number): Promise<void> => {
+  await client.delete(`/trades/${tradeId}`);
+};
+
 export const exportFills = async (params: TradeQuery): Promise<string> => {
   const response = await client.get("/trades/fills/export", {
     params,

--- a/frontend/src/components/TimezoneSelector.tsx
+++ b/frontend/src/components/TimezoneSelector.tsx
@@ -68,7 +68,10 @@ const TimezoneSelector = () => {
       value={timezone}
       loading={loading}
       onChange={handleChange}
-      filterOption={(input, option) => (option?.value ?? "").toLowerCase().includes(input.toLowerCase())}
+      filterOption={(input, option) => {
+        const optionValue = String(option?.value ?? "");
+        return optionValue.toLowerCase().includes(input.toLowerCase());
+      }}
     >
       {options.map((tz) => (
         <Select.Option key={tz} value={tz}>

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -64,6 +64,25 @@ const CalendarPage = () => {
     }
     const key = current.format("YYYY-MM-DD");
     const entry = data[key];
+    if (!entry) {
+      return (
+        <div
+          style={{
+            minHeight: 110,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            borderRadius: 8,
+            padding: 8
+          }}
+        >
+          <Typography.Text strong style={{ fontSize: 21 }}>
+            {current.date()}
+          </Typography.Text>
+        </div>
+      );
+    }
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
     const tradeCountText = `${entry?.trade_count ?? 0}笔`;
@@ -107,6 +126,25 @@ const CalendarPage = () => {
     }
     const key = current.format("YYYY-MM");
     const entry = data[key];
+    if (!entry) {
+      return (
+        <div
+          style={{
+            minHeight: 120,
+            borderRadius: 10,
+            padding: 12,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center"
+          }}
+        >
+          <Typography.Text strong style={{ fontSize: 21 }}>
+            {current.format("MM月")}
+          </Typography.Text>
+        </div>
+      );
+    }
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
     const tradeCountText = `${entry?.trade_count ?? 0}笔`;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -55,7 +55,7 @@ const Dashboard = () => {
     {
       key: "total",
       title: "总盈亏",
-      value: formatCurrency(totalProfit, currency)
+      value: formatCurrency(totalProfit, currency, false)
     },
     {
       key: "win_rate",
@@ -73,7 +73,7 @@ const Dashboard = () => {
     {
       key: "average",
       title: "平均盈亏",
-      value: formatCurrency(overview?.average_profit_loss ?? 0, currency)
+      value: formatCurrency(overview?.average_profit_loss ?? 0, currency, false)
     },
     {
       key: "count",
@@ -130,7 +130,7 @@ const Dashboard = () => {
               dataIndex: "total_profit_loss",
               render: (value: number) => (
                 <span style={{ color: value >= 0 ? "#3f8600" : "#cf1322" }}>
-                  {formatCurrency(value, currency)}
+                  {formatCurrency(value, currency, false)}
                 </span>
               )
             }

--- a/frontend/src/store/settingsSlice.ts
+++ b/frontend/src/store/settingsSlice.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Settings } from "../types";
+import { CurrencyCode, Settings } from "../types";
 
 interface SettingsState {
   timezone: string;
-  currency: string;
+  currency: CurrencyCode;
 }
 
 const initialState: SettingsState = {
@@ -18,7 +18,7 @@ const settingsSlice = createSlice({
     setTimezone(state, action: PayloadAction<string>) {
       state.timezone = action.payload;
     },
-    setCurrency(state, action: PayloadAction<string>) {
+    setCurrency(state, action: PayloadAction<CurrencyCode>) {
       state.currency = action.payload;
     },
     hydrateSettings(state, action: PayloadAction<Settings>) {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,11 +1,13 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezonePlugin from "dayjs/plugin/timezone";
+import quarterOfYear from "dayjs/plugin/quarterOfYear";
 
 import { DateRangePreset } from "../types";
 
 dayjs.extend(utc);
 dayjs.extend(timezonePlugin);
+dayjs.extend(quarterOfYear);
 
 export const computeRange = (preset: DateRangePreset, timezone: string): {
   start: string | null;
@@ -63,18 +65,24 @@ export const computeRange = (preset: DateRangePreset, timezone: string): {
   }
 };
 
-export const formatCurrency = (value: number, currency = "USD"): string => {
-  return new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2
-  }).format(value);
+export const formatCurrency = (value: number, currency = "USD", withSymbol = true): string => {
+  const options: Intl.NumberFormatOptions = {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  };
+
+  if (withSymbol) {
+    options.style = "currency";
+    options.currency = currency;
+  }
+
+  return new Intl.NumberFormat(undefined, options).format(value);
 };
 
 export const formatPercentage = (value: number): string => {
   return `${(value * 100).toFixed(2)}%`;
 };
 
-export const formatDateTime = (value: string, timezone: string): string => {
-  return dayjs(value).tz(timezone).format("YYYY-MM-DD HH:mm");
+export const formatDateTime = (value: string, timezone: string, withSeconds = false): string => {
+  return dayjs(value).tz(timezone).format(withSeconds ? "YYYY-MM-DD HH:mm:ss" : "YYYY-MM-DD HH:mm");
 };


### PR DESCRIPTION
## Summary
- keep trade API responses in their original currency values and add a per-trade delete endpoint
- refresh the trades table UI to drop the record ID, support single-trade deletion, and show timestamps with seconds
- remove currency symbols from dashboard totals, hide empty-day stats on the calendar, and add utility helpers for optional currency symbols

## Testing
- PYTHONPATH=. pytest *(fails: existing async_session fixture returns async generator without .add method)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cd9f21e3f4832aa8eb9cffc9d5ca03