### PR TITLE
Align calendar currency display and settings schema

### DIFF
--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db
@@ -13,8 +13,24 @@ from app.schemas.settings import SettingsRead, SettingsUpdate
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
+async def _ensure_currency_column(db: AsyncSession) -> None:
+    column_check = await db.execute(
+        text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name='user_settings' AND column_name='currency' LIMIT 1"
+        )
+    )
+    if column_check.scalar_one_or_none() is None:
+        await db.execute(
+            text("ALTER TABLE user_settings ADD COLUMN currency VARCHAR(10) DEFAULT 'USD'")
+        )
+        await db.execute(text("UPDATE user_settings SET currency = 'USD' WHERE currency IS NULL"))
+        await db.commit()
+
+
 @router.get("", response_model=SettingsRead)
 async def get_user_settings(db: AsyncSession = Depends(get_db)) -> SettingsRead:
+    await _ensure_currency_column(db)
     result = await db.execute(select(UserSetting).limit(1))
     setting = result.scalar_one_or_none()
     if setting is None:
@@ -31,6 +47,7 @@ async def update_user_settings(
     payload: SettingsUpdate,
     db: AsyncSession = Depends(get_db),
 ) -> SettingsRead:
+    await _ensure_currency_column(db)
     result = await db.execute(select(UserSetting).limit(1))
     setting = result.scalar_one_or_none()
     settings = get_settings()

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -8,7 +8,7 @@ import FilterBar from "../components/FilterBar";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { setDateRange, setPreset } from "../store/filterSlice";
 import { CalendarDay } from "../types";
-import { formatPercentage } from "../utils/date";
+import { formatCurrency } from "../utils/date";
 import { useNavigate } from "react-router-dom";
 
 const CalendarPage = () => {
@@ -77,7 +77,7 @@ const CalendarPage = () => {
             padding: 8
           }}
         >
-          <Typography.Text strong style={{ fontSize: 21 }}>
+          <Typography.Text strong style={{ fontSize: 24 }}>
             {current.date()}
           </Typography.Text>
         </div>
@@ -86,12 +86,9 @@ const CalendarPage = () => {
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
     const tradeCountText = `${entry?.trade_count ?? 0}笔`;
-    const winRateText = entry ? formatPercentage(entry.win_rate) : "0.00%";
+    const winRateText = `${Math.round((entry?.win_rate ?? 0) * 100)}%`;
     const profitLoss = entry?.total_profit_loss ?? 0;
-    const profitText = new Intl.NumberFormat(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    }).format(profitLoss);
+    const profitText = formatCurrency(profitLoss, currency, false, 0);
 
     return (
       <div
@@ -101,21 +98,31 @@ const CalendarPage = () => {
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
-          gap: 6,
+          gap: 10,
           borderRadius: 8,
-          padding: 8,
+          padding: 10,
           textAlign: "center",
-          background: entry ? (isPositive ? "#f6ffed" : "#fff1f0") : undefined
+          background: entry ? (isPositive ? "#b7eb8f" : "#ff9c8a") : undefined
         }}
       >
-        <Typography.Text strong style={{ fontSize: 21 }}>
+        <Typography.Text strong style={{ fontSize: 26 }}>
           {current.date()}
         </Typography.Text>
-        <Typography.Text>{tradeCountText}</Typography.Text>
-        <Typography.Text>{winRateText}</Typography.Text>
-        <Typography.Text style={{ color: isPositive ? "#3f8600" : "#cf1322" }}>
+        <Typography.Text style={{ fontSize: 20, color: isPositive ? "#3f8600" : "#cf1322" }}>
           {profitText}
         </Typography.Text>
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            fontSize: 16,
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+        >
+          <Typography.Text>{tradeCountText}</Typography.Text>
+          <Typography.Text>{winRateText}</Typography.Text>
+        </div>
       </div>
     );
   };
@@ -148,36 +155,43 @@ const CalendarPage = () => {
     const isPositive = (entry?.total_profit_loss ?? 0) >= 0;
 
     const tradeCountText = `${entry?.trade_count ?? 0}笔`;
-    const winRateText = entry ? formatPercentage(entry.win_rate) : "0.00%";
+    const winRateText = `${Math.round((entry?.win_rate ?? 0) * 100)}%`;
     const profitLoss = entry?.total_profit_loss ?? 0;
-    const profitText = new Intl.NumberFormat(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    }).format(profitLoss);
+    const profitText = formatCurrency(profitLoss, currency, false, 0);
 
     return (
       <div
         style={{
           minHeight: 120,
           borderRadius: 10,
-          padding: 12,
+          padding: 14,
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
-          gap: 8,
+          gap: 12,
           textAlign: "center",
-          background: entry ? (isPositive ? "#f6ffed" : "#fff1f0") : undefined
+          background: entry ? (isPositive ? "#b7eb8f" : "#ff9c8a") : undefined
         }}
       >
-        <Typography.Text strong style={{ fontSize: 21 }}>
+        <Typography.Text strong style={{ fontSize: 26 }}>
           {current.format("MM月")}
         </Typography.Text>
-        <Typography.Text>{tradeCountText}</Typography.Text>
-        <Typography.Text>{winRateText}</Typography.Text>
-        <Typography.Text style={{ color: isPositive ? "#3f8600" : "#cf1322" }}>
+        <Typography.Text style={{ fontSize: 20, color: isPositive ? "#3f8600" : "#cf1322" }}>
           {profitText}
         </Typography.Text>
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            fontSize: 16,
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+        >
+          <Typography.Text>{tradeCountText}</Typography.Text>
+          <Typography.Text>{winRateText}</Typography.Text>
+        </div>
       </div>
     );
   };

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -65,10 +65,15 @@ export const computeRange = (preset: DateRangePreset, timezone: string): {
   }
 };
 
-export const formatCurrency = (value: number, currency = "USD", withSymbol = true): string => {
+export const formatCurrency = (
+  value: number,
+  currency = "USD",
+  withSymbol = true,
+  fractionDigits = 2
+): string => {
   const options: Intl.NumberFormatOptions = {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits
   };
 
   if (withSymbol) {


### PR DESCRIPTION
## Summary
- display calendar profit/loss using the active currency without prefixes while enlarging typography, aligning metrics, and darkening status backgrounds
- allow customizable currency formatting precision so daily totals render as whole numbers
- automatically add the missing `currency` column on user settings fetch/update to keep timezone updates working

## Testing
- npm run build
- PYTHONPATH=. pytest *(fails: AttributeError: 'async_generator' object has no attribute 'add' in app/services/ibkr_importer.py::import_ibkr_csv)*

------
https://chatgpt.com/codex/tasks/task_e_68cda34ca8ac832a95580a6ca0f46197