### PR TITLE
Fix trade fill direction handling

### DIFF
--- a/backend/app/schemas/trade.py
+++ b/backend/app/schemas/trade.py
@@ -13,6 +13,7 @@ class TradeFillBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: int
     side: FillSide
+    direction: TradeDirection
     quantity: float
     price: float
     commission: float

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -107,6 +107,15 @@ const Trades = () => {
       columns={[
         {
           title: "方向",
+          dataIndex: "direction",
+          render: (value: TradeFill["direction"]) => (
+            <span style={{ color: value === "long" ? "#3f8600" : "#cf1322" }}>
+              {value === "long" ? "Long" : "Short"}
+            </span>
+          )
+        },
+        {
+          title: "买卖",
           dataIndex: "side",
           render: (value: TradeFill["side"]) => (value === "BUY" ? "Buy" : "Sell")
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,7 @@ export type CurrencyCode = "USD" | "HKD" | "EUR" | "JPY" | "CNY";
 export interface TradeFill {
   id: number;
   side: FillSide;
+  direction: TradeDirection;
   quantity: number;
   price: number;
   commission: number;


### PR DESCRIPTION
## Summary
- derive each trade fill's long/short direction from its Buy/Sell side when serializing API responses and Pine export data
- expose the derived direction through the TradeFill schema and surface it in the UI alongside the raw Buy/Sell side
- ensure the export comment text uses the computed direction so buy fills are labeled as long and sells as short

## Testing
- PYTHONPATH=backend pytest backend/app/tests/test_importer.py *(fails: async_session fixture yields an async generator when aiosqlite is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb0dcd3a0832aae1749999584bec2